### PR TITLE
Add the missing `.scalafix.conf` and handle the deprecated `JavaConverters` in cross-Scala versions

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,13 @@
+rules = [
+  Http4sGeneralLinters
+  Http4sUseLiteralsSyntax
+  LeakingImplicitClassVal
+  ExplicitResultTypes
+  OrganizeImports
+]
+
+triggered.rules = [
+  Http4sGeneralLinters
+  Http4sUseLiteralsSyntax
+  LeakingImplicitClassVal
+]

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val root = project
   .enablePlugins(NoPublishPlugin)
   .aggregate(jettyServer, jettyServerEe8, jettyClient, testing, client)
 
+val catsEffectVersion = "2.5.5"
 val http4sVersion = "0.22.15"
 val jettyVersion = "12.0.5"
 val nettyVersion = "4.1.76.Final"
@@ -39,10 +40,9 @@ lazy val jettyServer = project
     libraryDependencies ++= Seq(
       "org.eclipse.jetty" % "jetty-client" % jettyVersion % Test,
       "org.eclipse.jetty" % "jetty-util" % jettyVersion,
-      "org.eclipse.jetty.http2" % "jetty-http2-server" % jettyVersion,
-      "org.http4s" %% "http4s-servlet" % http4sVersion,
       "org.http4s" %% "http4s-dsl" % http4sVersion % Test,
       "org.slf4j" % "slf4j-simple" % slf4jVersion % Test,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion,
       "org.typelevel" %% "munit-cats-effect-2" % munitCatsEffectVersion % Test,
       "org.typelevel" %% "scalac-compat-annotation" % scalacCompatAnnotation % Test,
     ),
@@ -57,6 +57,8 @@ lazy val jettyServerEe8 = project
     description := "Jetty implementation for http4s servers on Java EE 8",
     libraryDependencies ++= Seq(
       "org.eclipse.jetty.ee8" % "jetty-ee8-servlet" % jettyVersion,
+      "org.eclipse.jetty.http2" % "jetty-http2-server" % jettyVersion,
+      "org.http4s" %% "http4s-servlet" % http4sVersion,
       "org.typelevel" %% "munit-cats-effect-2" % munitCatsEffectVersion % Test,
     ),
     jettyApiMappings,

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ val http4sVersion = "0.22.15"
 val jettyVersion = "12.0.5"
 val nettyVersion = "4.1.76.Final"
 val munitCatsEffectVersion = "1.0.7"
+val scalacCompatAnnotation = "0.1.4"
 val scalaJava8CompatVersion = "1.0.2"
 val slf4jVersion = "2.0.17"
 
@@ -43,6 +44,7 @@ lazy val jettyServer = project
       "org.http4s" %% "http4s-dsl" % http4sVersion % Test,
       "org.slf4j" % "slf4j-simple" % slf4jVersion % Test,
       "org.typelevel" %% "munit-cats-effect-2" % munitCatsEffectVersion % Test,
+      "org.typelevel" %% "scalac-compat-annotation" % scalacCompatAnnotation % Test,
     ),
     jettyApiMappings,
   )

--- a/client/src/test/scala-2.12/org/http4s/client/scaffold/JavaConverters.scala
+++ b/client/src/test/scala-2.12/org/http4s/client/scaffold/JavaConverters.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.client.scaffold
+
+import scala.collection.convert.DecorateAsJava
+import scala.collection.convert.DecorateAsScala
+
+object JavaConverters extends DecorateAsJava with DecorateAsScala

--- a/client/src/test/scala-2.13+/org/http4s/client/scaffold/JavaConverters.scala
+++ b/client/src/test/scala-2.13+/org/http4s/client/scaffold/JavaConverters.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.client.scaffold
+
+import scala.collection.convert.AsJavaExtensions
+import scala.collection.convert.AsScalaExtensions
+
+object JavaConverters extends AsJavaExtensions with AsScalaExtensions

--- a/client/src/test/scala/org/http4s/client/scaffold/RoutesToNettyAdapter.scala
+++ b/client/src/test/scala/org/http4s/client/scaffold/RoutesToNettyAdapter.scala
@@ -33,10 +33,10 @@ import org.http4s.Headers
 import org.http4s.HttpRoutes
 import org.http4s.Method
 import org.http4s.Response
+import org.http4s.client.scaffold.JavaConverters._
 import org.http4s.headers.`Transfer-Encoding`
 
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
 
 object RoutesToNettyAdapter {
   def apply[F[_]](routes: HttpRoutes[F])(implicit

--- a/client/src/test/scala/org/http4s/client/scaffold/RoutesToNettyAdapter.scala
+++ b/client/src/test/scala/org/http4s/client/scaffold/RoutesToNettyAdapter.scala
@@ -60,6 +60,7 @@ class RoutesToHandlerAdapter[F[_]](
 )(implicit F: ConcurrentEffect[F])
     extends Handler {
 
+  @nowarn212("cat=deprecation")
   override def onRequestStart(ctx: ChannelHandlerContext, request: HttpRequest): Unit =
     (
       for {
@@ -68,7 +69,7 @@ class RoutesToHandlerAdapter[F[_]](
         headers = http4s.Headers(request.headers().names().asScala.toVector.flatMap { k =>
           val vs = request.headers().getAll(k)
           vs.asScala.toVector.map(v => (k -> v): http4s.Header.ToRaw)
-        }): @nowarn212("cat=deprecation")
+        })
         bodyQueue <- Queue.unbounded[F, Option[Chunk[Byte]]]
         _ <- requestBodyQueue.set(bodyQueue)
         body = bodyQueue.dequeue.unNoneTerminate.flatMap(Stream.chunk)

--- a/client/src/test/scala/org/http4s/client/scaffold/RoutesToNettyAdapter.scala
+++ b/client/src/test/scala/org/http4s/client/scaffold/RoutesToNettyAdapter.scala
@@ -35,8 +35,7 @@ import org.http4s.Method
 import org.http4s.Response
 import org.http4s.client.scaffold.JavaConverters._
 import org.http4s.headers.`Transfer-Encoding`
-
-import scala.annotation.nowarn
+import org.typelevel.scalaccompat.annotation.nowarn212
 
 object RoutesToNettyAdapter {
   def apply[F[_]](routes: HttpRoutes[F])(implicit
@@ -69,7 +68,7 @@ class RoutesToHandlerAdapter[F[_]](
         headers = http4s.Headers(request.headers().names().asScala.toVector.flatMap { k =>
           val vs = request.headers().getAll(k)
           vs.asScala.toVector.map(v => (k -> v): http4s.Header.ToRaw)
-        }): @nowarn("cat=deprecation")
+        }): @nowarn212("cat=deprecation")
         bodyQueue <- Queue.unbounded[F, Option[Chunk[Byte]]]
         _ <- requestBodyQueue.set(bodyQueue)
         body = bodyQueue.dequeue.unNoneTerminate.flatMap(Stream.chunk)


### PR DESCRIPTION
## Add the missing `.scalafix.conf`

I think the build for `0.22` failed due to the missing `.scalafix.conf`.

## Handle the deprecated JavaConverters in cross-Scala versions

- `scala.collection.JavaConverters` is deprecated in Scala 2.13 and higher, and `scala.jdk.CollectionConverters` should be used instead, but 2.12 has only `scala.collection.JavaConverters`.