### PR TITLE
Add Jetty EE9 and EE10 modules to support Servlet 5 and 6 for `http4s` version `0.22`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,15 +82,15 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' unusedCompileDependenciesTest
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p jetty-server/target jetty-server-ee8/target jetty-client/target project/target
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        run: mkdir -p jetty-server/target jetty-server-ee8/target jetty-server-ee9/target jetty-server-ee10/target jetty-client/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar jetty-server/target jetty-server-ee8/target jetty-client/target project/target
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        run: tar cf targets.tar jetty-server/target jetty-server-ee8/target jetty-server-ee9/target jetty-server-ee10/target jetty-client/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
@@ -99,7 +99,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
         os: [ubuntu-22.04]

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ val Scala213 = "2.13.16"
 ThisBuild / crossScalaVersions := Seq(Scala213, "2.12.20", "3.3.5")
 ThisBuild / scalaVersion := Scala213 // the default Scala
 ThisBuild / tlJdkRelease := Some(17)
+ThisBuild / tlMimaPreviousVersions ~= { orig => orig -- Set("0.22.0") }
 ThisBuild / githubWorkflowJavaVersions ~= {
   // Jetty 12 bumps the requirement to Java 17
   _.filter { case JavaSpec(_, major) => major.toInt >= 17 }

--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,19 @@ ThisBuild / githubWorkflowJavaVersions ~= {
 lazy val root = project
   .in(file("."))
   .enablePlugins(NoPublishPlugin)
-  .aggregate(jettyServer, jettyServerEe8, jettyClient, testing, client)
+  .aggregate(
+    jettyServer,
+    jettyServerEe8,
+    jettyServerEe9,
+    jettyServerEe10,
+    jettyClient,
+    testing,
+    client,
+  )
 
 val catsEffectVersion = "2.5.5"
 val http4sVersion = "0.22.15"
+val http4sServletVersion = "0.22.0-M1"
 val jettyVersion = "12.0.20"
 val nettyVersion = "4.1.115.Final"
 val munitCatsEffectVersion = "1.0.7"
@@ -58,7 +67,37 @@ lazy val jettyServerEe8 = project
     libraryDependencies ++= Seq(
       "org.eclipse.jetty.ee8" % "jetty-ee8-servlet" % jettyVersion,
       "org.eclipse.jetty.http2" % "jetty-http2-server" % jettyVersion,
-      "org.http4s" %% "http4s-servlet" % http4sVersion,
+      "org.http4s" %% "http4s-servlet4" % http4sServletVersion,
+      "org.typelevel" %% "munit-cats-effect-2" % munitCatsEffectVersion % Test,
+    ),
+    jettyApiMappings,
+  )
+  .dependsOn(jettyServer % "compile;test->test")
+
+lazy val jettyServerEe9 = project
+  .in(file("jetty-server-ee9"))
+  .settings(
+    name := "http4s-jetty12-server-ee9",
+    description := "Jetty implementation for http4s servers on Java EE 8",
+    libraryDependencies ++= Seq(
+      "org.eclipse.jetty.ee9" % "jetty-ee9-servlet" % jettyVersion,
+      "org.eclipse.jetty.http2" % "jetty-http2-server" % jettyVersion,
+      "org.http4s" %% "http4s-servlet5" % http4sServletVersion,
+      "org.typelevel" %% "munit-cats-effect-2" % munitCatsEffectVersion % Test,
+    ),
+    jettyApiMappings,
+  )
+  .dependsOn(jettyServer % "compile;test->test")
+
+lazy val jettyServerEe10 = project
+  .in(file("jetty-server-ee10"))
+  .settings(
+    name := "http4s-jetty12-server-ee10",
+    description := "Jetty implementation for http4s servers on Java EE 10",
+    libraryDependencies ++= Seq(
+      "org.eclipse.jetty.ee10" % "jetty-ee10-servlet" % jettyVersion,
+      "org.eclipse.jetty.http2" % "jetty-http2-server" % jettyVersion,
+      "org.http4s" %% "http4s-servlet6" % http4sServletVersion,
       "org.typelevel" %% "munit-cats-effect-2" % munitCatsEffectVersion % Test,
     ),
     jettyApiMappings,

--- a/jetty-server-ee10/src/main/scala/org/http4s/jetty12/server/ee10/JettyBuilder.scala
+++ b/jetty-server-ee10/src/main/scala/org/http4s/jetty12/server/ee10/JettyBuilder.scala
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package jetty12
+package server
+package ee10
+
+import cats.effect._
+import cats.syntax.all._
+import jakarta.servlet.DispatcherType
+import jakarta.servlet.Filter
+import jakarta.servlet.http.HttpServlet
+import org.eclipse.jetty.ee10.servlet.FilterHolder
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler
+import org.eclipse.jetty.ee10.servlet.ServletHolder
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server.handler.StatisticsHandler
+import org.eclipse.jetty.server.{Server => JServer}
+import org.eclipse.jetty.util.ssl.SslContextFactory
+import org.eclipse.jetty.util.thread.ThreadPool
+import org.http4s.jetty12.server.ee10.JettyBuilder._
+import org.http4s.server.DefaultServiceErrorHandler
+import org.http4s.server.SSLClientAuthMode
+import org.http4s.server.SSLKeyStoreSupport.StoreInfo
+import org.http4s.server.Server
+import org.http4s.server.ServerBuilder
+import org.http4s.server.ServiceErrorHandler
+import org.http4s.server.defaults
+import org.http4s.servlet.AsyncHttp4sServlet
+import org.http4s.servlet.ServletContainer
+import org.http4s.servlet.ServletIo
+import org.http4s.syntax.all._
+import org.log4s.getLogger
+
+import java.net.InetSocketAddress
+import java.util
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLParameters
+import scala.collection.immutable
+import scala.concurrent.duration._
+
+sealed class JettyBuilder[F[_]] private (
+    socketAddress: InetSocketAddress,
+    private val threadPool: ThreadPool,
+    threadPoolResourceOption: Option[Resource[F, ThreadPool]],
+    private val idleTimeout: Duration,
+    private val asyncTimeout: Duration,
+    shutdownTimeout: Duration,
+    private val servletIo: ServletIo[F],
+    sslConfig: SslConfig,
+    mounts: Vector[Mount[F]],
+    private val serviceErrorHandler: ServiceErrorHandler[F],
+    supportHttp2: Boolean,
+    banner: immutable.Seq[String],
+    jettyHttpConfiguration: HttpConfiguration,
+)(implicit protected val F: ConcurrentEffect[F])
+    extends ServletContainer[F]
+    with ServerBuilder[F] {
+  type Self = JettyBuilder[F]
+
+  private[this] val logger = getLogger
+
+  private def copy(
+      socketAddress: InetSocketAddress = socketAddress,
+      threadPool: ThreadPool = threadPool,
+      threadPoolResourceOption: Option[Resource[F, ThreadPool]] = threadPoolResourceOption,
+      idleTimeout: Duration = idleTimeout,
+      asyncTimeout: Duration = asyncTimeout,
+      shutdownTimeout: Duration = shutdownTimeout,
+      servletIo: ServletIo[F] = servletIo,
+      sslConfig: SslConfig = sslConfig,
+      mounts: Vector[Mount[F]] = mounts,
+      serviceErrorHandler: ServiceErrorHandler[F] = serviceErrorHandler,
+      supportHttp2: Boolean = supportHttp2,
+      banner: immutable.Seq[String] = banner,
+      jettyHttpConfiguration: HttpConfiguration = jettyHttpConfiguration,
+  ): Self =
+    new JettyBuilder(
+      socketAddress,
+      threadPool,
+      threadPoolResourceOption,
+      idleTimeout,
+      asyncTimeout,
+      shutdownTimeout,
+      servletIo,
+      sslConfig,
+      mounts,
+      serviceErrorHandler,
+      supportHttp2,
+      banner,
+      jettyHttpConfiguration,
+    )
+
+  @deprecated(
+    "Build an `SSLContext` from the first four parameters and use `withSslContext` (note lowercase). To also request client certificates, use `withSslContextAndParameters, calling either `.setWantClientAuth(true)` or `setNeedClientAuth(true)` on the `SSLParameters`.",
+    "0.21.0-RC3",
+  )
+  def withSSL(
+      keyStore: StoreInfo,
+      keyManagerPassword: String,
+      protocol: String = "TLS",
+      trustStore: Option[StoreInfo] = None,
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested,
+  ): Self =
+    copy(sslConfig =
+      new KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
+    )
+
+  @deprecated(
+    "Use `withSslContext` (note lowercase). To request client certificates, use `withSslContextAndParameters, calling either `.setWantClientAuth(true)` or `setNeedClientAuth(true)` on the `SSLParameters`.",
+    "0.21.0-RC3",
+  )
+  def withSSLContext(
+      sslContext: SSLContext,
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested,
+  ): Self =
+    copy(sslConfig = new ContextWithClientAuth(sslContext, clientAuth))
+
+  /** Configures the server with TLS, using the provided `SSLContext` and its
+    * default `SSLParameters`
+    */
+  def withSslContext(sslContext: SSLContext): Self =
+    copy(sslConfig = new ContextOnly(sslContext))
+
+  /** Configures the server with TLS, using the provided `SSLContext` and its
+    * default `SSLParameters`
+    */
+  def withSslContextAndParameters(sslContext: SSLContext, sslParameters: SSLParameters): Self =
+    copy(sslConfig = new ContextWithParameters(sslContext, sslParameters))
+
+  /** Disables SSL. */
+  def withoutSsl: Self =
+    copy(sslConfig = NoSsl)
+
+  override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
+    copy(socketAddress = socketAddress)
+
+  /** Set the [[org.eclipse.jetty.util.thread.ThreadPool]] that Jetty will use.
+    *
+    * It is recommended you use [[JettyThreadPools#resource]] to build this so
+    * that it will be gracefully shutdown when/if the Jetty server is
+    * shutdown.
+    */
+  def withThreadPoolResource(threadPoolResource: Resource[F, ThreadPool]): JettyBuilder[F] =
+    copy(threadPoolResourceOption = Some(threadPoolResource))
+
+  /** Set the [[org.eclipse.jetty.util.thread.ThreadPool]] that Jetty will use.
+    *
+    * @note You should prefer [[withThreadPoolResource]] instead of this
+    *       method. If you invoke this method the provided
+    *       [[org.eclipse.jetty.util.thread.ThreadPool]] ''will not'' be
+    *       joined, stopped, or destroyed when/if the Jetty server stops. This
+    *       is to preserve the <= 0.21.23 semantics.
+    */
+  @deprecated(
+    message = "Please use withThreadPoolResource instead and see JettyThreadPools.",
+    since = "0.21.23",
+  )
+  def withThreadPool(threadPool: ThreadPool): JettyBuilder[F] =
+    copy(threadPoolResourceOption = None, threadPool = new UndestroyableThreadPool(threadPool))
+
+  override def mountServlet(
+      servlet: HttpServlet,
+      urlMapping: String,
+      name: Option[String] = None,
+  ): Self =
+    copy(mounts = mounts :+ Mount[F] { (context, index, _) =>
+      val servletName = name.getOrElse(s"servlet-$index")
+      context.addServlet(new ServletHolder(servletName, servlet), urlMapping)
+    })
+
+  override def mountFilter(
+      filter: Filter,
+      urlMapping: String,
+      name: Option[String],
+      dispatches: util.EnumSet[DispatcherType],
+  ): Self =
+    copy(mounts = mounts :+ Mount[F] { (context, index, _) =>
+      val filterName = name.getOrElse(s"filter-$index")
+      val filterHolder = new FilterHolder(filter)
+      filterHolder.setName(filterName)
+      context.addFilter(filterHolder, urlMapping, dispatches)
+    })
+
+  def mountService(service: HttpRoutes[F], prefix: String): Self =
+    mountHttpApp(service.orNotFound, prefix)
+
+  def mountHttpApp(service: HttpApp[F], prefix: String): Self =
+    copy(mounts = mounts :+ Mount[F] { (context, index, builder) =>
+      val servlet = new AsyncHttp4sServlet(
+        service = service,
+        asyncTimeout = builder.asyncTimeout,
+        servletIo = builder.servletIo,
+        serviceErrorHandler = builder.serviceErrorHandler,
+      )
+      val servletName = s"servlet-$index"
+      val urlMapping = ServletContainer.prefixMapping(prefix)
+      context.addServlet(new ServletHolder(servletName, servlet), urlMapping)
+    })
+
+  def withIdleTimeout(idleTimeout: Duration): Self =
+    copy(idleTimeout = idleTimeout)
+
+  def withAsyncTimeout(asyncTimeout: Duration): Self =
+    copy(asyncTimeout = asyncTimeout)
+
+  /** Sets the graceful shutdown timeout for Jetty.  Closing the resource
+    * will wait this long before a forcible stop.
+    */
+  def withShutdownTimeout(shutdownTimeout: Duration): Self =
+    copy(shutdownTimeout = shutdownTimeout)
+
+  override def withServletIo(servletIo: ServletIo[F]): Self =
+    copy(servletIo = servletIo)
+
+  def withServiceErrorHandler(serviceErrorHandler: ServiceErrorHandler[F]): Self =
+    copy(serviceErrorHandler = serviceErrorHandler)
+
+  /** Enables HTTP/2 connection upgrade over plain text (no TLS).
+    * See https://webtide.com/introduction-to-http2-in-jetty
+    */
+  def withHttp2c: Self =
+    copy(supportHttp2 = true)
+
+  def withoutHttp2c: Self =
+    copy(supportHttp2 = false)
+
+  def withBanner(banner: immutable.Seq[String]): Self =
+    copy(banner = banner)
+
+  /** Provide a specific [[org.eclipse.jetty.server.HttpConfiguration]].
+    *
+    * This can be used for direct low level control over many HTTP related
+    * configuration settings which http4s may not directly expose.
+    */
+  def withJettyHttpConfiguration(value: HttpConfiguration): Self =
+    copy(jettyHttpConfiguration = value)
+
+  private def getConnector(jetty: JServer): ServerConnector = {
+
+    val http1: HttpConnectionFactory = new HttpConnectionFactory(jettyHttpConfiguration)
+
+    sslConfig.makeSslContextFactory match {
+      case Some(sslContextFactory) =>
+        if (supportHttp2) logger.warn("JettyBuilder does not support HTTP/2 with SSL at the moment")
+        new ServerConnector(jetty, sslContextFactory, http1)
+
+      case None =>
+        if (!supportHttp2) {
+          new ServerConnector(jetty, http1)
+        } else {
+          val http2c = new HTTP2CServerConnectionFactory(jettyHttpConfiguration)
+          new ServerConnector(jetty, http1, http2c)
+        }
+    }
+  }
+
+  def resource: Resource[F, Server] = {
+    // If threadPoolResourceOption is None, then use the value of
+    // threadPool.
+    val threadPoolR: Resource[F, ThreadPool] =
+      threadPoolResourceOption.getOrElse(
+        Resource.pure(threadPool)
+      )
+    val serverR: ThreadPool => Resource[F, Server] = (threadPool: ThreadPool) =>
+      JettyLifeCycle
+        .lifeCycleAsResource[F, JServer](
+          F.delay {
+            val jetty = new JServer(threadPool)
+            val context = new ServletContextHandler()
+
+            context.setContextPath("/")
+
+            jetty.setHandler(context)
+
+            val connector = getConnector(jetty)
+
+            connector.setHost(socketAddress.getHostString)
+            connector.setPort(socketAddress.getPort)
+            connector.setIdleTimeout(if (idleTimeout.isFinite) idleTimeout.toMillis else -1)
+            jetty.addConnector(connector)
+
+            // Jetty graceful shutdown does not work without a stats handler
+            val stats = new StatisticsHandler
+            stats.setHandler(jetty.getHandler)
+            jetty.setHandler(stats)
+
+            jetty.setStopTimeout(shutdownTimeout match {
+              case d: FiniteDuration => d.toMillis
+              case _ => 0L
+            })
+
+            for ((mount, i) <- mounts.zipWithIndex)
+              mount.f(context, i, this)
+
+            jetty
+          }
+        )
+        .map((jetty: JServer) =>
+          new Server {
+            lazy val address: InetSocketAddress = {
+              val host = socketAddress.getHostString
+              val port = jetty.getConnectors()(0).asInstanceOf[ServerConnector].getLocalPort
+              new InetSocketAddress(host, port)
+            }
+
+            lazy val isSecure: Boolean = sslConfig.isSecure
+          }
+        )
+    for {
+      threadPool <- threadPoolR
+      server <- serverR(threadPool)
+      _ <- Resource.eval(banner.traverse_(value => F.delay(logger.info(value))))
+      _ <- Resource.eval(
+        F.delay(
+          logger.info(
+            s"http4s v${BuildInfo.version} on Jetty v${JServer.getVersion} started at ${server.baseUri}"
+          )
+        )
+      )
+    } yield server
+  }
+}
+
+object JettyBuilder {
+  def apply[F[_]: ConcurrentEffect] =
+    new JettyBuilder[F](
+      socketAddress = defaults.IPv4SocketAddress,
+      threadPool = LazyThreadPool.newLazyThreadPool,
+      threadPoolResourceOption = Some(
+        JettyThreadPools.default[F]
+      ),
+      idleTimeout = defaults.IdleTimeout,
+      asyncTimeout = defaults.ResponseTimeout,
+      shutdownTimeout = defaults.ShutdownTimeout,
+      servletIo = ServletContainer.DefaultServletIo,
+      sslConfig = NoSsl,
+      mounts = Vector.empty,
+      serviceErrorHandler = DefaultServiceErrorHandler,
+      supportHttp2 = false,
+      banner = defaults.Banner,
+      jettyHttpConfiguration = defaultJettyHttpConfiguration,
+    )
+
+  private sealed trait SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server]
+    def isSecure: Boolean
+  }
+
+  private class KeyStoreBits(
+      keyStore: StoreInfo,
+      keyManagerPassword: String,
+      protocol: String,
+      trustStore: Option[StoreInfo],
+      clientAuth: SSLClientAuthMode,
+  ) extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = {
+      val sslContextFactory = new SslContextFactory.Server()
+      sslContextFactory.setKeyStorePath(keyStore.path)
+      sslContextFactory.setKeyStorePassword(keyStore.password)
+      sslContextFactory.setKeyManagerPassword(keyManagerPassword)
+      sslContextFactory.setProtocol(protocol)
+      updateClientAuth(sslContextFactory, clientAuth)
+
+      trustStore.foreach { trustManagerBits =>
+        sslContextFactory.setTrustStorePath(trustManagerBits.path)
+        sslContextFactory.setTrustStorePassword(trustManagerBits.password)
+      }
+      sslContextFactory.some
+    }
+    def isSecure = true
+  }
+
+  private class ContextWithClientAuth(sslContext: SSLContext, clientAuth: SSLClientAuthMode)
+      extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = {
+      val sslContextFactory = new SslContextFactory.Server()
+      sslContextFactory.setSslContext(sslContext)
+      updateClientAuth(sslContextFactory, clientAuth)
+      sslContextFactory.some
+    }
+    def isSecure = true
+  }
+
+  private class ContextOnly(sslContext: SSLContext) extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = {
+      val sslContextFactory = new SslContextFactory.Server()
+      sslContextFactory.setSslContext(sslContext)
+      sslContextFactory.some
+    }
+    def isSecure = true
+  }
+
+  private class ContextWithParameters(sslContext: SSLContext, sslParameters: SSLParameters)
+      extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = {
+      val sslContextFactory = new SslContextFactory.Server()
+      sslContextFactory.setSslContext(sslContext)
+      sslContextFactory.customize(sslParameters)
+      sslContextFactory.some
+    }
+    def isSecure = true
+  }
+
+  private object NoSsl extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = None
+    def isSecure = false
+  }
+
+  private def updateClientAuth(
+      sslContextFactory: SslContextFactory.Server,
+      clientAuthMode: SSLClientAuthMode,
+  ): Unit =
+    clientAuthMode match {
+      case SSLClientAuthMode.NotRequested =>
+        sslContextFactory.setWantClientAuth(false)
+        sslContextFactory.setNeedClientAuth(false)
+
+      case SSLClientAuthMode.Requested =>
+        sslContextFactory.setWantClientAuth(true)
+
+      case SSLClientAuthMode.Required =>
+        sslContextFactory.setNeedClientAuth(true)
+    }
+
+  /** The default [[org.eclipse.jetty.server.HttpConfiguration]] to use with jetty. */
+  private val defaultJettyHttpConfiguration: HttpConfiguration = {
+    val config: HttpConfiguration = new HttpConfiguration()
+    config.setRequestHeaderSize(defaults.MaxHeadersSize)
+    config
+  }
+}
+
+private final case class Mount[F[_]](f: (ServletContextHandler, Int, JettyBuilder[F]) => Unit)

--- a/jetty-server-ee10/src/test/scala/org/http4s/jetty12/server/Issue454.scala
+++ b/jetty-server-ee10/src/test/scala/org/http4s/jetty12/server/Issue454.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package jetty
+package server
+
+import cats.effect.ContextShift
+import cats.effect.IO
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler
+import org.eclipse.jetty.ee10.servlet.ServletHolder
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import org.http4s.dsl.io._
+import org.http4s.server.DefaultServiceErrorHandler
+import org.http4s.servlet.AsyncHttp4sServlet
+import org.http4s.syntax.all._
+
+object Issue454 {
+  implicit val cs: ContextShift[IO] = Http4sSuite.TestContextShift
+
+  // If the bug is not triggered right away, try increasing or
+  // repeating the request. Also if you decrease the data size (to
+  // say 32mb, the bug does not manifest so often, but the stack
+  // trace is a bit different.
+  private val insanelyHugeData = Array.ofDim[Byte](1024 * 1024 * 128)
+
+  {
+    var i = 0
+    while (i < insanelyHugeData.length) {
+      insanelyHugeData(i) = ('0' + i).toByte
+      i = i + 1
+    }
+    insanelyHugeData(insanelyHugeData.length - 1) = '-' // end marker
+  }
+
+  def main(args: Array[String]): Unit = {
+    val server = new Server
+
+    val connector = new ServerConnector(server, new HttpConnectionFactory(new HttpConfiguration()))
+    connector.setPort(5555)
+
+    val context = new ServletContextHandler
+    context.setContextPath("/")
+    context.addServlet(new ServletHolder(servlet), "/")
+
+    server.addConnector(connector)
+    server.setHandler(context)
+
+    server.start()
+  }
+
+  val servlet = new AsyncHttp4sServlet[IO](
+    service = HttpRoutes
+      .of[IO] { case GET -> Root =>
+        Ok(insanelyHugeData)
+      }
+      .orNotFound,
+    servletIo = org.http4s.servlet.NonBlockingServletIo(4096),
+    serviceErrorHandler = DefaultServiceErrorHandler,
+  )
+}

--- a/jetty-server-ee10/src/test/scala/org/http4s/jetty12/server/ee10/JettyServerSuite.scala
+++ b/jetty-server-ee10/src/test/scala/org/http4s/jetty12/server/ee10/JettyServerSuite.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package jetty12
+package server
+package ee10
+
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.effect.Timer
+import org.http4s.dsl.io._
+import org.http4s.server.Server
+import org.http4s.testing.AutoCloseableResource
+
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import scala.concurrent.duration._
+import scala.io.Source
+
+class JettyServerSuite extends Http4sSuite {
+  implicit val contextShift: ContextShift[IO] = Http4sSuite.TestContextShift
+
+  private def builder = JettyBuilder[IO]
+
+  private val serverR =
+    builder
+      .bindAny()
+      .withAsyncTimeout(3.seconds)
+      .mountService(
+        HttpRoutes.of {
+          case GET -> Root / "thread" / "routing" =>
+            val thread = Thread.currentThread.getName
+            Ok(thread)
+
+          case GET -> Root / "thread" / "effect" =>
+            IO(Thread.currentThread.getName).flatMap(Ok(_))
+
+          case req @ POST -> Root / "echo" =>
+            Ok(req.body)
+
+          case GET -> Root / "never" =>
+            IO.never
+
+          case GET -> Root / "slow" =>
+            implicitly[Timer[IO]].sleep(50.millis) *> Ok("slow")
+        },
+        "/",
+      )
+      .resource
+
+  private val jettyServer = ResourceFixture[Server](serverR)
+
+  private def get(server: Server, path: String): IO[String] =
+    testBlocker.blockOn(
+      IO(
+        AutoCloseableResource.resource(
+          Source
+            .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
+        )(_.getLines().mkString)
+      )
+    )
+
+  private def post(server: Server, path: String, body: String): IO[String] =
+    testBlocker.blockOn(IO {
+      val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
+      val conn = url.openConnection().asInstanceOf[HttpURLConnection]
+      val bytes = body.getBytes(StandardCharsets.UTF_8)
+      conn.setRequestMethod("POST")
+      conn.setRequestProperty("Content-Length", bytes.size.toString)
+      conn.setDoOutput(true)
+      conn.getOutputStream.write(bytes)
+
+      AutoCloseableResource.resource(
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
+      )(_.getLines().mkString)
+    })
+
+  jettyServer.test("ChannelOptions should should route requests on the service executor") {
+    server =>
+      get(server, "/thread/routing").map(_.startsWith("http4s-suite-")).assert
+  }
+
+  jettyServer.test(
+    "ChannelOptions should should execute the service task on the service executor"
+  ) { server =>
+    get(server, "/thread/effect").map(_.startsWith("http4s-suite-")).assert
+  }
+
+  jettyServer.test("ChannelOptions should be able to echo its input") { server =>
+    val input = """{ "Hello": "world" }"""
+    post(server, "/echo", input).map(_.startsWith(input)).assert
+  }
+
+  jettyServer.test("Timeout not fire prematurely") { server =>
+    get(server, "/slow").assertEquals("slow")
+  }
+
+  jettyServer.test("Timeout should fire on timeout".flaky) { server =>
+    get(server, "/never").intercept[IOException]
+  }
+
+  jettyServer.test("Timeout should execute the service task on the service executor") { server =>
+    get(server, "/thread/effect").map(_.startsWith("http4s-suite-")).assert
+  }
+}

--- a/jetty-server-ee9/src/main/scala/org/http4s/jetty12/server/ee9/JettyBuilder.scala
+++ b/jetty-server-ee9/src/main/scala/org/http4s/jetty12/server/ee9/JettyBuilder.scala
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package jetty12
+package server
+package ee9
+
+import cats.effect._
+import cats.syntax.all._
+import jakarta.servlet.DispatcherType
+import jakarta.servlet.Filter
+import jakarta.servlet.http.HttpServlet
+import org.eclipse.jetty.ee9.servlet.FilterHolder
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler
+import org.eclipse.jetty.ee9.servlet.ServletHolder
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server.handler.StatisticsHandler
+import org.eclipse.jetty.server.{Server => JServer}
+import org.eclipse.jetty.util.ssl.SslContextFactory
+import org.eclipse.jetty.util.thread.ThreadPool
+import org.http4s.jetty12.server.ee9.JettyBuilder._
+import org.http4s.server.DefaultServiceErrorHandler
+import org.http4s.server.SSLClientAuthMode
+import org.http4s.server.SSLKeyStoreSupport.StoreInfo
+import org.http4s.server.Server
+import org.http4s.server.ServerBuilder
+import org.http4s.server.ServiceErrorHandler
+import org.http4s.server.defaults
+import org.http4s.servlet.AsyncHttp4sServlet
+import org.http4s.servlet.ServletContainer
+import org.http4s.servlet.ServletIo
+import org.http4s.syntax.all._
+import org.log4s.getLogger
+
+import java.net.InetSocketAddress
+import java.util
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLParameters
+import scala.collection.immutable
+import scala.concurrent.duration._
+
+sealed class JettyBuilder[F[_]] private (
+    socketAddress: InetSocketAddress,
+    private val threadPool: ThreadPool,
+    threadPoolResourceOption: Option[Resource[F, ThreadPool]],
+    private val idleTimeout: Duration,
+    private val asyncTimeout: Duration,
+    shutdownTimeout: Duration,
+    private val servletIo: ServletIo[F],
+    sslConfig: SslConfig,
+    mounts: Vector[Mount[F]],
+    private val serviceErrorHandler: ServiceErrorHandler[F],
+    supportHttp2: Boolean,
+    banner: immutable.Seq[String],
+    jettyHttpConfiguration: HttpConfiguration,
+)(implicit protected val F: ConcurrentEffect[F])
+    extends ServletContainer[F]
+    with ServerBuilder[F] {
+  type Self = JettyBuilder[F]
+
+  private[this] val logger = getLogger
+
+  private def copy(
+      socketAddress: InetSocketAddress = socketAddress,
+      threadPool: ThreadPool = threadPool,
+      threadPoolResourceOption: Option[Resource[F, ThreadPool]] = threadPoolResourceOption,
+      idleTimeout: Duration = idleTimeout,
+      asyncTimeout: Duration = asyncTimeout,
+      shutdownTimeout: Duration = shutdownTimeout,
+      servletIo: ServletIo[F] = servletIo,
+      sslConfig: SslConfig = sslConfig,
+      mounts: Vector[Mount[F]] = mounts,
+      serviceErrorHandler: ServiceErrorHandler[F] = serviceErrorHandler,
+      supportHttp2: Boolean = supportHttp2,
+      banner: immutable.Seq[String] = banner,
+      jettyHttpConfiguration: HttpConfiguration = jettyHttpConfiguration,
+  ): Self =
+    new JettyBuilder(
+      socketAddress,
+      threadPool,
+      threadPoolResourceOption,
+      idleTimeout,
+      asyncTimeout,
+      shutdownTimeout,
+      servletIo,
+      sslConfig,
+      mounts,
+      serviceErrorHandler,
+      supportHttp2,
+      banner,
+      jettyHttpConfiguration,
+    )
+
+  @deprecated(
+    "Build an `SSLContext` from the first four parameters and use `withSslContext` (note lowercase). To also request client certificates, use `withSslContextAndParameters, calling either `.setWantClientAuth(true)` or `setNeedClientAuth(true)` on the `SSLParameters`.",
+    "0.21.0-RC3",
+  )
+  def withSSL(
+      keyStore: StoreInfo,
+      keyManagerPassword: String,
+      protocol: String = "TLS",
+      trustStore: Option[StoreInfo] = None,
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested,
+  ): Self =
+    copy(sslConfig =
+      new KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
+    )
+
+  @deprecated(
+    "Use `withSslContext` (note lowercase). To request client certificates, use `withSslContextAndParameters, calling either `.setWantClientAuth(true)` or `setNeedClientAuth(true)` on the `SSLParameters`.",
+    "0.21.0-RC3",
+  )
+  def withSSLContext(
+      sslContext: SSLContext,
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested,
+  ): Self =
+    copy(sslConfig = new ContextWithClientAuth(sslContext, clientAuth))
+
+  /** Configures the server with TLS, using the provided `SSLContext` and its
+    * default `SSLParameters`
+    */
+  def withSslContext(sslContext: SSLContext): Self =
+    copy(sslConfig = new ContextOnly(sslContext))
+
+  /** Configures the server with TLS, using the provided `SSLContext` and its
+    * default `SSLParameters`
+    */
+  def withSslContextAndParameters(sslContext: SSLContext, sslParameters: SSLParameters): Self =
+    copy(sslConfig = new ContextWithParameters(sslContext, sslParameters))
+
+  /** Disables SSL. */
+  def withoutSsl: Self =
+    copy(sslConfig = NoSsl)
+
+  override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
+    copy(socketAddress = socketAddress)
+
+  /** Set the [[org.eclipse.jetty.util.thread.ThreadPool]] that Jetty will use.
+    *
+    * It is recommended you use [[JettyThreadPools#resource]] to build this so
+    * that it will be gracefully shutdown when/if the Jetty server is
+    * shutdown.
+    */
+  def withThreadPoolResource(threadPoolResource: Resource[F, ThreadPool]): JettyBuilder[F] =
+    copy(threadPoolResourceOption = Some(threadPoolResource))
+
+  /** Set the [[org.eclipse.jetty.util.thread.ThreadPool]] that Jetty will use.
+    *
+    * @note You should prefer [[withThreadPoolResource]] instead of this
+    *       method. If you invoke this method the provided
+    *       [[org.eclipse.jetty.util.thread.ThreadPool]] ''will not'' be
+    *       joined, stopped, or destroyed when/if the Jetty server stops. This
+    *       is to preserve the <= 0.21.23 semantics.
+    */
+  @deprecated(
+    message = "Please use withThreadPoolResource instead and see JettyThreadPools.",
+    since = "0.21.23",
+  )
+  def withThreadPool(threadPool: ThreadPool): JettyBuilder[F] =
+    copy(threadPoolResourceOption = None, threadPool = new UndestroyableThreadPool(threadPool))
+
+  override def mountServlet(
+      servlet: HttpServlet,
+      urlMapping: String,
+      name: Option[String] = None,
+  ): Self =
+    copy(mounts = mounts :+ Mount[F] { (context, index, _) =>
+      val servletName = name.getOrElse(s"servlet-$index")
+      context.addServlet(new ServletHolder(servletName, servlet), urlMapping)
+    })
+
+  override def mountFilter(
+      filter: Filter,
+      urlMapping: String,
+      name: Option[String],
+      dispatches: util.EnumSet[DispatcherType],
+  ): Self =
+    copy(mounts = mounts :+ Mount[F] { (context, index, _) =>
+      val filterName = name.getOrElse(s"filter-$index")
+      val filterHolder = new FilterHolder(filter)
+      filterHolder.setName(filterName)
+      context.addFilter(filterHolder, urlMapping, dispatches)
+    })
+
+  def mountService(service: HttpRoutes[F], prefix: String): Self =
+    mountHttpApp(service.orNotFound, prefix)
+
+  def mountHttpApp(service: HttpApp[F], prefix: String): Self =
+    copy(mounts = mounts :+ Mount[F] { (context, index, builder) =>
+      val servlet = new AsyncHttp4sServlet(
+        service = service,
+        asyncTimeout = builder.asyncTimeout,
+        servletIo = builder.servletIo,
+        serviceErrorHandler = builder.serviceErrorHandler,
+      )
+      val servletName = s"servlet-$index"
+      val urlMapping = ServletContainer.prefixMapping(prefix)
+      context.addServlet(new ServletHolder(servletName, servlet), urlMapping)
+    })
+
+  def withIdleTimeout(idleTimeout: Duration): Self =
+    copy(idleTimeout = idleTimeout)
+
+  def withAsyncTimeout(asyncTimeout: Duration): Self =
+    copy(asyncTimeout = asyncTimeout)
+
+  /** Sets the graceful shutdown timeout for Jetty.  Closing the resource
+    * will wait this long before a forcible stop.
+    */
+  def withShutdownTimeout(shutdownTimeout: Duration): Self =
+    copy(shutdownTimeout = shutdownTimeout)
+
+  override def withServletIo(servletIo: ServletIo[F]): Self =
+    copy(servletIo = servletIo)
+
+  def withServiceErrorHandler(serviceErrorHandler: ServiceErrorHandler[F]): Self =
+    copy(serviceErrorHandler = serviceErrorHandler)
+
+  /** Enables HTTP/2 connection upgrade over plain text (no TLS).
+    * See https://webtide.com/introduction-to-http2-in-jetty
+    */
+  def withHttp2c: Self =
+    copy(supportHttp2 = true)
+
+  def withoutHttp2c: Self =
+    copy(supportHttp2 = false)
+
+  def withBanner(banner: immutable.Seq[String]): Self =
+    copy(banner = banner)
+
+  /** Provide a specific [[org.eclipse.jetty.server.HttpConfiguration]].
+    *
+    * This can be used for direct low level control over many HTTP related
+    * configuration settings which http4s may not directly expose.
+    */
+  def withJettyHttpConfiguration(value: HttpConfiguration): Self =
+    copy(jettyHttpConfiguration = value)
+
+  private def getConnector(jetty: JServer): ServerConnector = {
+
+    val http1: HttpConnectionFactory = new HttpConnectionFactory(jettyHttpConfiguration)
+
+    sslConfig.makeSslContextFactory match {
+      case Some(sslContextFactory) =>
+        if (supportHttp2) logger.warn("JettyBuilder does not support HTTP/2 with SSL at the moment")
+        new ServerConnector(jetty, sslContextFactory, http1)
+
+      case None =>
+        if (!supportHttp2) {
+          new ServerConnector(jetty, http1)
+        } else {
+          val http2c = new HTTP2CServerConnectionFactory(jettyHttpConfiguration)
+          new ServerConnector(jetty, http1, http2c)
+        }
+    }
+  }
+
+  def resource: Resource[F, Server] = {
+    // If threadPoolResourceOption is None, then use the value of
+    // threadPool.
+    val threadPoolR: Resource[F, ThreadPool] =
+      threadPoolResourceOption.getOrElse(
+        Resource.pure(threadPool)
+      )
+    val serverR: ThreadPool => Resource[F, Server] = (threadPool: ThreadPool) =>
+      JettyLifeCycle
+        .lifeCycleAsResource[F, JServer](
+          F.delay {
+            val jetty = new JServer(threadPool)
+            val context = new ServletContextHandler()
+
+            context.setContextPath("/")
+
+            jetty.setHandler(context)
+
+            val connector = getConnector(jetty)
+
+            connector.setHost(socketAddress.getHostString)
+            connector.setPort(socketAddress.getPort)
+            connector.setIdleTimeout(if (idleTimeout.isFinite) idleTimeout.toMillis else -1)
+            jetty.addConnector(connector)
+
+            // Jetty graceful shutdown does not work without a stats handler
+            val stats = new StatisticsHandler
+            stats.setHandler(jetty.getHandler)
+            jetty.setHandler(stats)
+
+            jetty.setStopTimeout(shutdownTimeout match {
+              case d: FiniteDuration => d.toMillis
+              case _ => 0L
+            })
+
+            for ((mount, i) <- mounts.zipWithIndex)
+              mount.f(context, i, this)
+
+            jetty
+          }
+        )
+        .map((jetty: JServer) =>
+          new Server {
+            lazy val address: InetSocketAddress = {
+              val host = socketAddress.getHostString
+              val port = jetty.getConnectors()(0).asInstanceOf[ServerConnector].getLocalPort
+              new InetSocketAddress(host, port)
+            }
+
+            lazy val isSecure: Boolean = sslConfig.isSecure
+          }
+        )
+    for {
+      threadPool <- threadPoolR
+      server <- serverR(threadPool)
+      _ <- Resource.eval(banner.traverse_(value => F.delay(logger.info(value))))
+      _ <- Resource.eval(
+        F.delay(
+          logger.info(
+            s"http4s v${BuildInfo.version} on Jetty v${JServer.getVersion} started at ${server.baseUri}"
+          )
+        )
+      )
+    } yield server
+  }
+}
+
+object JettyBuilder {
+  def apply[F[_]: ConcurrentEffect] =
+    new JettyBuilder[F](
+      socketAddress = defaults.IPv4SocketAddress,
+      threadPool = LazyThreadPool.newLazyThreadPool,
+      threadPoolResourceOption = Some(
+        JettyThreadPools.default[F]
+      ),
+      idleTimeout = defaults.IdleTimeout,
+      asyncTimeout = defaults.ResponseTimeout,
+      shutdownTimeout = defaults.ShutdownTimeout,
+      servletIo = ServletContainer.DefaultServletIo,
+      sslConfig = NoSsl,
+      mounts = Vector.empty,
+      serviceErrorHandler = DefaultServiceErrorHandler,
+      supportHttp2 = false,
+      banner = defaults.Banner,
+      jettyHttpConfiguration = defaultJettyHttpConfiguration,
+    )
+
+  private sealed trait SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server]
+    def isSecure: Boolean
+  }
+
+  private class KeyStoreBits(
+      keyStore: StoreInfo,
+      keyManagerPassword: String,
+      protocol: String,
+      trustStore: Option[StoreInfo],
+      clientAuth: SSLClientAuthMode,
+  ) extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = {
+      val sslContextFactory = new SslContextFactory.Server()
+      sslContextFactory.setKeyStorePath(keyStore.path)
+      sslContextFactory.setKeyStorePassword(keyStore.password)
+      sslContextFactory.setKeyManagerPassword(keyManagerPassword)
+      sslContextFactory.setProtocol(protocol)
+      updateClientAuth(sslContextFactory, clientAuth)
+
+      trustStore.foreach { trustManagerBits =>
+        sslContextFactory.setTrustStorePath(trustManagerBits.path)
+        sslContextFactory.setTrustStorePassword(trustManagerBits.password)
+      }
+      sslContextFactory.some
+    }
+    def isSecure = true
+  }
+
+  private class ContextWithClientAuth(sslContext: SSLContext, clientAuth: SSLClientAuthMode)
+      extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = {
+      val sslContextFactory = new SslContextFactory.Server()
+      sslContextFactory.setSslContext(sslContext)
+      updateClientAuth(sslContextFactory, clientAuth)
+      sslContextFactory.some
+    }
+    def isSecure = true
+  }
+
+  private class ContextOnly(sslContext: SSLContext) extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = {
+      val sslContextFactory = new SslContextFactory.Server()
+      sslContextFactory.setSslContext(sslContext)
+      sslContextFactory.some
+    }
+    def isSecure = true
+  }
+
+  private class ContextWithParameters(sslContext: SSLContext, sslParameters: SSLParameters)
+      extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = {
+      val sslContextFactory = new SslContextFactory.Server()
+      sslContextFactory.setSslContext(sslContext)
+      sslContextFactory.customize(sslParameters)
+      sslContextFactory.some
+    }
+    def isSecure = true
+  }
+
+  private object NoSsl extends SslConfig {
+    def makeSslContextFactory: Option[SslContextFactory.Server] = None
+    def isSecure = false
+  }
+
+  private def updateClientAuth(
+      sslContextFactory: SslContextFactory.Server,
+      clientAuthMode: SSLClientAuthMode,
+  ): Unit =
+    clientAuthMode match {
+      case SSLClientAuthMode.NotRequested =>
+        sslContextFactory.setWantClientAuth(false)
+        sslContextFactory.setNeedClientAuth(false)
+
+      case SSLClientAuthMode.Requested =>
+        sslContextFactory.setWantClientAuth(true)
+
+      case SSLClientAuthMode.Required =>
+        sslContextFactory.setNeedClientAuth(true)
+    }
+
+  /** The default [[org.eclipse.jetty.server.HttpConfiguration]] to use with jetty. */
+  private val defaultJettyHttpConfiguration: HttpConfiguration = {
+    val config: HttpConfiguration = new HttpConfiguration()
+    config.setRequestHeaderSize(defaults.MaxHeadersSize)
+    config
+  }
+}
+
+private final case class Mount[F[_]](f: (ServletContextHandler, Int, JettyBuilder[F]) => Unit)

--- a/jetty-server-ee9/src/test/scala/org/http4s/jetty12/server/Issue454.scala
+++ b/jetty-server-ee9/src/test/scala/org/http4s/jetty12/server/Issue454.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package jetty
+package server
+
+import cats.effect.ContextShift
+import cats.effect.IO
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler
+import org.eclipse.jetty.ee9.servlet.ServletHolder
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import org.http4s.dsl.io._
+import org.http4s.server.DefaultServiceErrorHandler
+import org.http4s.servlet.AsyncHttp4sServlet
+import org.http4s.syntax.all._
+
+object Issue454 {
+  implicit val cs: ContextShift[IO] = Http4sSuite.TestContextShift
+
+  // If the bug is not triggered right away, try increasing or
+  // repeating the request. Also if you decrease the data size (to
+  // say 32mb, the bug does not manifest so often, but the stack
+  // trace is a bit different.
+  private val insanelyHugeData = Array.ofDim[Byte](1024 * 1024 * 128)
+
+  {
+    var i = 0
+    while (i < insanelyHugeData.length) {
+      insanelyHugeData(i) = ('0' + i).toByte
+      i = i + 1
+    }
+    insanelyHugeData(insanelyHugeData.length - 1) = '-' // end marker
+  }
+
+  def main(args: Array[String]): Unit = {
+    val server = new Server
+
+    val connector = new ServerConnector(server, new HttpConnectionFactory(new HttpConfiguration()))
+    connector.setPort(5555)
+
+    val context = new ServletContextHandler
+    context.setContextPath("/")
+    context.addServlet(new ServletHolder(servlet), "/")
+
+    server.addConnector(connector)
+    server.setHandler(context)
+
+    server.start()
+  }
+
+  val servlet = new AsyncHttp4sServlet[IO](
+    service = HttpRoutes
+      .of[IO] { case GET -> Root =>
+        Ok(insanelyHugeData)
+      }
+      .orNotFound,
+    servletIo = org.http4s.servlet.NonBlockingServletIo(4096),
+    serviceErrorHandler = DefaultServiceErrorHandler,
+  )
+}

--- a/jetty-server-ee9/src/test/scala/org/http4s/jetty12/server/ee9/JettyServerSuite.scala
+++ b/jetty-server-ee9/src/test/scala/org/http4s/jetty12/server/ee9/JettyServerSuite.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package jetty12
+package server
+package ee9
+
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.effect.Timer
+import org.http4s.dsl.io._
+import org.http4s.server.Server
+import org.http4s.testing.AutoCloseableResource
+
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import scala.concurrent.duration._
+import scala.io.Source
+
+class JettyServerSuite extends Http4sSuite {
+  implicit val contextShift: ContextShift[IO] = Http4sSuite.TestContextShift
+
+  private def builder = JettyBuilder[IO]
+
+  private val serverR =
+    builder
+      .bindAny()
+      .withAsyncTimeout(3.seconds)
+      .mountService(
+        HttpRoutes.of {
+          case GET -> Root / "thread" / "routing" =>
+            val thread = Thread.currentThread.getName
+            Ok(thread)
+
+          case GET -> Root / "thread" / "effect" =>
+            IO(Thread.currentThread.getName).flatMap(Ok(_))
+
+          case req @ POST -> Root / "echo" =>
+            Ok(req.body)
+
+          case GET -> Root / "never" =>
+            IO.never
+
+          case GET -> Root / "slow" =>
+            implicitly[Timer[IO]].sleep(50.millis) *> Ok("slow")
+        },
+        "/",
+      )
+      .resource
+
+  private val jettyServer = ResourceFixture[Server](serverR)
+
+  private def get(server: Server, path: String): IO[String] =
+    testBlocker.blockOn(
+      IO(
+        AutoCloseableResource.resource(
+          Source
+            .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
+        )(_.getLines().mkString)
+      )
+    )
+
+  private def post(server: Server, path: String, body: String): IO[String] =
+    testBlocker.blockOn(IO {
+      val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
+      val conn = url.openConnection().asInstanceOf[HttpURLConnection]
+      val bytes = body.getBytes(StandardCharsets.UTF_8)
+      conn.setRequestMethod("POST")
+      conn.setRequestProperty("Content-Length", bytes.size.toString)
+      conn.setDoOutput(true)
+      conn.getOutputStream.write(bytes)
+
+      AutoCloseableResource.resource(
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
+      )(_.getLines().mkString)
+    })
+
+  jettyServer.test("ChannelOptions should should route requests on the service executor") {
+    server =>
+      get(server, "/thread/routing").map(_.startsWith("http4s-suite-")).assert
+  }
+
+  jettyServer.test(
+    "ChannelOptions should should execute the service task on the service executor"
+  ) { server =>
+    get(server, "/thread/effect").map(_.startsWith("http4s-suite-")).assert
+  }
+
+  jettyServer.test("ChannelOptions should be able to echo its input") { server =>
+    val input = """{ "Hello": "world" }"""
+    post(server, "/echo", input).map(_.startsWith(input)).assert
+  }
+
+  jettyServer.test("Timeout not fire prematurely") { server =>
+    get(server, "/slow").assertEquals("slow")
+  }
+
+  jettyServer.test("Timeout should fire on timeout".flaky) { server =>
+    get(server, "/never").intercept[IOException]
+  }
+
+  jettyServer.test("Timeout should execute the service task on the service executor") { server =>
+    get(server, "/thread/effect").map(_.startsWith("http4s-suite-")).assert
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "1.0.1")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "2.0.0")


### PR DESCRIPTION
Add Jetty EE9 and EE10 modules to support Servlet 5 and 6 for `http4s` version `0.22`

- Add new modules, `http4s-jetty12-server-ee9` and `http4s-jetty12-server-ee10`, to support Jetty 12 with Servlet 5 and Servlet 6, respectively.
- `http4s-jetty12-server-ee9` supports Servlet 5 (with `http4s-servlet5`).
- `http4s-jetty12-server-ee10` supports Servlet 6 (with `http4s-servlet6`).
- Update imports in `JettyBuilder` from `javax.servlet` to `jakarta.servlet` for Servlet 5 and 6.
- Update the `http4s-servlet` version to `0.22.0-M1` for the new servlet APIs (`http4s-servlet4`, `http4s-servlet5`, and `http4s-servlet6`), including updating the existing `http4s-jetty12-server-ee8` to use `http4s-servlet4`.

***
Also,
- Upgrade `sbt` from `1.10.1` to `1.11.2` for releasing to the Maven Central Portal.
- Upgrade `sbt-http4s-org` plugin from `1.0.1` to `2.0.0`.