### PR TITLE
Close #338: Support for Jetty 12 with Jakarta EE 8 to address CVE-2024-6763

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         scala: [2.13, 2.12, 3]
-        java: [temurin@11, temurin@17]
-        exclude:
-          - scala: 2.12
-            java: temurin@17
-          - scala: 3
-            java: temurin@17
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -46,19 +41,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -77,26 +59,26 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
         run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' doc
 
       - name: Check scalafix lints
-        if: matrix.java == 'temurin@11' && !startsWith(matrix.scala, '3')
+        if: matrix.java == 'temurin@17' && !startsWith(matrix.scala, '3')
         run: sbt '++ ${{ matrix.scala }}' 'scalafixAll --check'
 
       - name: Check unused compile dependencies
-        if: matrix.java == 'temurin@11'
+        if: matrix.java == 'temurin@17'
         run: sbt '++ ${{ matrix.scala }}' unusedCompileDependenciesTest
 
       - name: Make target directories
@@ -121,7 +103,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -131,19 +113,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -218,7 +187,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -228,19 +197,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -266,7 +222,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -276,19 +232,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17

--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,10 @@ ThisBuild / tlSitePublishBranch := Some("main")
 val Scala213 = "2.13.16"
 ThisBuild / crossScalaVersions := Seq(Scala213, "2.12.20", "3.3.6")
 ThisBuild / scalaVersion := Scala213 // the default Scala
-ThisBuild / tlJdkRelease := Some(11)
+ThisBuild / tlJdkRelease := Some(17)
 ThisBuild / githubWorkflowJavaVersions ~= {
-  // Jetty 10 bumps the requirement to Java 11
-  _.filter { case JavaSpec(_, major) => major.toInt >= 11 }
+  // The minimum required Java version for Jetty 12 is 17.
+  _.filter { case JavaSpec(_, major) => major.toInt >= 17 }
 }
 
 ThisBuild / resolvers +=
@@ -29,7 +29,7 @@ lazy val root = project
   .enablePlugins(NoPublishPlugin)
   .aggregate(jettyServer, jettyClient)
 
-val jettyVersion = "10.0.25"
+val jettyVersion = "12.0.23"
 val http4sVersion = "0.23.30"
 val http4sServletVersion = "0.24.0-RC3"
 val munitCatsEffectVersion = "2.1.0"
@@ -42,9 +42,9 @@ lazy val jettyServer = project
     description := "Jetty implementation for http4s servers",
     libraryDependencies ++= Seq(
       "org.eclipse.jetty" % "jetty-client" % jettyVersion % Test,
-      "org.eclipse.jetty" % "jetty-servlet" % jettyVersion,
+      "org.eclipse.jetty.ee8" % "jetty-ee8-servlet" % jettyVersion,
       "org.eclipse.jetty" % "jetty-util" % jettyVersion,
-      "org.eclipse.jetty.http2" % "http2-server" % jettyVersion,
+      "org.eclipse.jetty.http2" % "jetty-http2-server" % jettyVersion,
       "org.http4s" %% "http4s-dsl" % http4sVersion % Test,
       "org.http4s" %% "http4s-servlet" % http4sServletVersion,
       "org.typelevel" %% "munit-cats-effect" % munitCatsEffectVersion % Test,

--- a/jetty-client/src/main/scala/org/http4s/jetty/client/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/jetty/client/JettyClient.scala
@@ -23,7 +23,7 @@ import cats.effect.std.Dispatcher
 import cats.syntax.all._
 import fs2._
 import org.eclipse.jetty.client.HttpClient
-import org.eclipse.jetty.client.api.{Request => JettyRequest}
+import org.eclipse.jetty.client.{Request => JettyRequest}
 import org.eclipse.jetty.http.{HttpVersion => JHttpVersion}
 import org.http4s.client.Client
 import org.log4s.Logger

--- a/jetty-client/src/main/scala/org/http4s/jetty/client/ResponseListener.scala
+++ b/jetty-client/src/main/scala/org/http4s/jetty/client/ResponseListener.scala
@@ -24,11 +24,11 @@ import cats.effect.std.Queue
 import cats.syntax.all._
 import fs2.Stream._
 import fs2._
-import org.eclipse.jetty.client.api.Result
-import org.eclipse.jetty.client.api.{Response => JettyResponse}
+import org.eclipse.jetty.client.Result
+import org.eclipse.jetty.client.{Response => JettyResponse}
 import org.eclipse.jetty.http.HttpFields
 import org.eclipse.jetty.http.{HttpVersion => JHttpVersion}
-import org.eclipse.jetty.util.{Callback => JettyCallback}
+import org.eclipse.jetty.io.Content
 import org.http4s.internal.CollectionCompat.CollectionConverters._
 import org.http4s.jetty.client.ResponseListener.Item
 import org.http4s.jetty.client.internal.loggingAsyncCallback
@@ -41,7 +41,7 @@ private[jetty] final case class ResponseListener[F[_]](
     cb: Callback[Resource[F, Response[F]]],
     dispatcher: Dispatcher[F],
 )(implicit F: Async[F])
-    extends JettyResponse.Listener.Adapter {
+    extends JettyResponse.Listener {
   import ResponseListener.logger
 
   /* Needed to properly propagate client errors */
@@ -88,15 +88,16 @@ private[jetty] final case class ResponseListener[F[_]](
 
   override def onContent(
       response: JettyResponse,
-      content: ByteBuffer,
-      callback: JettyCallback,
+      chunk: Content.Chunk,
+      demander: Runnable,
   ): Unit = {
+    val content = chunk.getByteBuffer
     val copy = ByteBuffer.allocate(content.remaining())
     copy.put(content).flip()
     enqueue(Item.Buf(copy)) {
-      case Right(_) => F.delay(callback.succeeded())
+      case Right(_) => F.delay(demander.run())
       case Left(e) =>
-        F.delay(logger.error(e)("Error in asynchronous callback")) >> F.delay(callback.failed(e))
+        F.delay(logger.error(e)("Error in asynchronous callback"))
     }
   }
 
@@ -116,10 +117,19 @@ private[jetty] final case class ResponseListener[F[_]](
   override def onComplete(result: Result): Unit = ()
 
   private def abort(t: Throwable, response: JettyResponse): Unit =
-    if (!response.abort(t)) // this also aborts the request
-      logger.error(t)("Failed to abort the response")
-    else
-      closeStream()
+    dispatcher.unsafeRunAndForget(
+      F.fromCompletableFuture(F.delay(response.abort(t)))
+        .map { aborted =>
+          if (!aborted)
+            logger.error(t)("Failed to abort the response")
+          else
+            closeStream()
+        }
+        .attempt
+        .flatMap {
+          loggingAsyncCallback(logger)(_)
+        }
+    )
 
   private def closeStream(): Unit =
     enqueue(Item.Done)(loggingAsyncCallback[F, Unit](logger))

--- a/jetty-client/src/main/scala/org/http4s/jetty/client/StreamRequestContent.scala
+++ b/jetty-client/src/main/scala/org/http4s/jetty/client/StreamRequestContent.scala
@@ -22,7 +22,7 @@ import cats.effect._
 import cats.effect.std._
 import cats.syntax.all._
 import fs2._
-import org.eclipse.jetty.client.util.AsyncRequestContent
+import org.eclipse.jetty.client.AsyncRequestContent
 import org.eclipse.jetty.util.{Callback => JettyCallback}
 import org.http4s.jetty.client.internal.loggingAsyncCallback
 import org.log4s.getLogger
@@ -43,15 +43,11 @@ private[jetty] class StreamRequestContent[F[_]] private (
       .onError { case t => F.delay(logger.error(t)("Unable to write to Jetty sink")) }
 
   private val pipe: Pipe[F, Chunk[Byte], Unit] =
-    _.evalMap { c =>
-      write(c)
-        .ensure(new Exception("something terrible has happened"))(res => res)
-        .map(_ => ())
-    }
+    _.evalMap(chunk => write(chunk))
 
-  private def write(chunk: Chunk[Byte]): F[Boolean] =
+  private def write(chunk: Chunk[Byte]): F[Unit] =
     s.acquire
-      .map(_ => super.offer(chunk.toByteBuffer, callback))
+      .map(_ => super.write(chunk.toByteBuffer, callback))
 
   private val callback: JettyCallback = new JettyCallback {
     override def succeeded(): Unit =

--- a/jetty-server/src/main/scala/org/http4s/jetty/server/JettyBuilder.scala
+++ b/jetty-server/src/main/scala/org/http4s/jetty/server/JettyBuilder.scala
@@ -22,15 +22,15 @@ import cats.effect._
 import cats.effect.kernel.Async
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
+import org.eclipse.jetty.ee8.servlet.FilterHolder
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler
+import org.eclipse.jetty.ee8.servlet.ServletHolder
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.HttpConnectionFactory
 import org.eclipse.jetty.server.ServerConnector
 import org.eclipse.jetty.server.handler.StatisticsHandler
 import org.eclipse.jetty.server.{Server => JServer}
-import org.eclipse.jetty.servlet.FilterHolder
-import org.eclipse.jetty.servlet.ServletContextHandler
-import org.eclipse.jetty.servlet.ServletHolder
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.thread.ThreadPool
 import org.http4s.jetty.server.JettyBuilder._

--- a/jetty-server/src/test/scala/org/http4s/jetty/server/JettyServerSuite.scala
+++ b/jetty-server/src/test/scala/org/http4s/jetty/server/JettyServerSuite.scala
@@ -24,8 +24,8 @@ import cats.effect.Temporal
 import munit.CatsEffectSuite
 import munit.catseffect.IOFixture
 import org.eclipse.jetty.client.HttpClient
-import org.eclipse.jetty.client.api.Request
-import org.eclipse.jetty.client.util.StringRequestContent
+import org.eclipse.jetty.client.Request
+import org.eclipse.jetty.client.StringRequestContent
 import org.http4s.dsl.io._
 import org.http4s.server.Server
 


### PR DESCRIPTION
Close #338: Support for Jetty 12 with Jakarta EE 8 to address CVE-2024-6763

- Upgrade Jetty from 10.0.25 to 12.0.23.
- Update Jetty dependencies to use new EE8 modules (jetty-ee8-servlet, jetty-http2-server).
- Update the code in accordance with the changes in Jetty `12`.
- Bump minimum Java version from 11 to 17 (required by Jetty 12)