### PR TITLE
Close #339: Support for Jetty 12 with Jakarta EE 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p jetty-server/target jetty-server-ee8/target jetty-client/target project/target
+        run: mkdir -p jetty-server/target jetty-server-ee9/target jetty-client/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar jetty-server/target jetty-server-ee8/target jetty-client/target project/target
+        run: tar cf targets.tar jetty-server/target jetty-server-ee9/target jetty-client/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.typelevel.sbt.gha
 
-ThisBuild / tlBaseVersion := "0.26" // your current series x.y
+ThisBuild / tlBaseVersion := "0.27" // your current series x.y
 
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(
@@ -27,12 +27,12 @@ ThisBuild / resolvers +=
 lazy val root = project
   .in(file("."))
   .enablePlugins(NoPublishPlugin)
-  .aggregate(jettyServer, jettyServerEe8, jettyClient)
+  .aggregate(jettyServer, jettyServerEe9, jettyClient)
 
 val catsEffectVersion = "3.6.3"
-val jettyVersion = "12.0.23"
+val jettyVersion = "12.0.25"
 val http4sVersion = "0.23.30"
-val http4sServletVersion = "0.24.0-RC2"
+val http4sServletVersion = "0.25.0-RC1"
 val munitCatsEffectVersion = "2.1.0"
 val slf4jVersion = "1.7.25"
 val scalaJava8Compat = "1.0.2"
@@ -52,13 +52,13 @@ lazy val jettyServer = project
     jettyApiMappings,
   )
 
-lazy val jettyServerEe8 = project
-  .in(file("jetty-server-ee8"))
+lazy val jettyServerEe9 = project
+  .in(file("jetty-server-ee9"))
   .settings(
-    name := "http4s-jetty-server-ee8",
+    name := "http4s-jetty-server-ee9",
     description := "Jetty implementation for http4s servers",
     libraryDependencies ++= Seq(
-      "org.eclipse.jetty.ee8" % "jetty-ee8-servlet" % jettyVersion,
+      "org.eclipse.jetty.ee9" % "jetty-ee9-servlet" % jettyVersion,
       "org.eclipse.jetty.http2" % "jetty-http2-server" % jettyVersion,
       "org.http4s" %% "http4s-server" % http4sVersion,
       "org.http4s" %% "http4s-servlet" % http4sServletVersion,
@@ -79,7 +79,7 @@ lazy val examples = project
       "org.slf4j" % "slf4j-simple" % slf4jVersion % Runtime
     ),
   )
-  .dependsOn(jettyServer)
+  .dependsOn(jettyServerEe9)
 
 lazy val jettyClient = project
   .in(file("jetty-client"))

--- a/examples/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -19,14 +19,10 @@ package jetty
 
 import cats.effect._
 import org.http4s._
-import org.http4s.jetty.server.JettyBuilder
+import org.http4s.jetty.server.ee9.JettyBuilder
 import org.http4s.server.Server
-import org.http4s.servlet.DefaultFilter
-
-import javax.servlet.FilterChain
-import javax.servlet.http.HttpServlet
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.{HttpFilter, HttpServlet, HttpServletRequest, HttpServletResponse}
 
 /** 1. Run as `sbt examples/run`
   * 2. Browse to http://localhost:8080/http4s to see `httpRoutes`
@@ -54,8 +50,8 @@ class JettyExample[F[_]](implicit F: Async[F]) {
   }
 
   // Also supports raw filters alongside your http4s routes
-  val filter = new DefaultFilter {
-    override def doHttpFilter(
+  val filter = new HttpFilter {
+    override def doFilter(
         request: HttpServletRequest,
         response: HttpServletResponse,
         chain: FilterChain,
@@ -63,6 +59,7 @@ class JettyExample[F[_]](implicit F: Async[F]) {
       response.setStatus(403)
       response.getWriter.print("None shall pass!")
     }
+
   }
 
   def resource: Resource[F, Server] =

--- a/jetty-server-ee9/src/main/scala/org/http4s/jetty/server/ee9/JettyBuilder.scala
+++ b/jetty-server-ee9/src/main/scala/org/http4s/jetty/server/ee9/JettyBuilder.scala
@@ -17,15 +17,18 @@
 package org.http4s
 package jetty
 package server
-package ee8
+package ee9
 
 import cats.effect._
 import cats.effect.kernel.Async
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
-import org.eclipse.jetty.ee8.servlet.FilterHolder
-import org.eclipse.jetty.ee8.servlet.ServletContextHandler
-import org.eclipse.jetty.ee8.servlet.ServletHolder
+import jakarta.servlet.DispatcherType
+import jakarta.servlet.http.HttpFilter
+import jakarta.servlet.http.HttpServlet
+import org.eclipse.jetty.ee9.servlet.FilterHolder
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler
+import org.eclipse.jetty.ee9.servlet.ServletHolder
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.HttpConnectionFactory
@@ -34,7 +37,7 @@ import org.eclipse.jetty.server.handler.StatisticsHandler
 import org.eclipse.jetty.server.{Server => JServer}
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.thread.ThreadPool
-import org.http4s.jetty.server.ee8.JettyBuilder._
+import org.http4s.jetty.server.ee9.JettyBuilder._
 import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.server.Server
 import org.http4s.server.ServerBuilder
@@ -50,9 +53,6 @@ import java.net.InetSocketAddress
 import java.util
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLParameters
-import javax.servlet.DispatcherType
-import javax.servlet.http.HttpFilter
-import javax.servlet.http.HttpServlet
 import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.duration._

--- a/jetty-server-ee9/src/test/scala/org/http4s/jetty/server/ee9/JettyServerSuite.scala
+++ b/jetty-server-ee9/src/test/scala/org/http4s/jetty/server/ee9/JettyServerSuite.scala
@@ -17,7 +17,7 @@
 package org.http4s
 package jetty
 package server
-package ee8
+package ee9
 
 import cats.effect.IO
 import cats.effect.Resource


### PR DESCRIPTION
## Close #339: Support for Jetty 12 with Jakarta EE 9

Migrate to Jetty EE9 (Jakarta)

- tlBaseVersion: `0.26` -> `0.27`
- Rename module: `jetty-server-ee8` -> `jetty-server-ee9`
- Update: `examples` `dependsOn` to use `ee9`
- Move packages: `org.http4s.jetty.server.ee8` -> `org.http4s.jetty.server.ee9`
- Switch Jetty imports: `org.eclipse.jetty.ee8.servlet.*` -> `org.eclipse.jetty.ee9.servlet.*`
- Migrate Servlet API: `javax.*` -> `jakarta.*` (`server` and `examples`)
- examples: use `org.http4s.jetty.server.ee9.JettyBuilder`; replace `DefaultFilter.doHttpFilter` with `HttpFilter.doFilter`
- Bump versions: Jetty `12.0.23` -> `12.0.25`, http4s-servlet `0.24.0-RC2` -> `0.25.0-RC1`